### PR TITLE
Добавлено ограничение контейнера embed

### DIFF
--- a/components/ExtEmbed/ExtEmbed.scss
+++ b/components/ExtEmbed/ExtEmbed.scss
@@ -19,6 +19,10 @@
 .ext-embed {
     position: relative;
 
+    max-width: 100%;
+
+    overflow-x: hidden;
+
     &__iframe {
         overflow: hidden;
 


### PR DESCRIPTION
Для подстраховки от кейсов, когда в iframe устанавливается размр шире
экрана и появляется горизонтальный скрол